### PR TITLE
Fixed the unassigned outbound call issue

### DIFF
--- a/src/assets/scripts/topBar/contactEvents.js
+++ b/src/assets/scripts/topBar/contactEvents.js
@@ -167,7 +167,7 @@ const handleContactEnded = async () => {
         await appendTicketComments.appendTheRest(session.contact, session.ticketId);
         if (appSettings.speechAnalysisEnabled)
             speechAnalysis.updateTicketAttribute(session.ticketId.toString());
-    } else if (appSettings.forceTicketCreation && !(session.isMonitoring) && !unassignedOutboundCall) {
+    } else if (appSettings.forceTicketCreation && !session.isMonitoring && !unassignedOutboundCall) {
         // manual assignment mode, the agent has forgotten to assign - force ticket creation (if configured)
         // set the agent as a requester
         session.user = { name: session.contact.customerNo, id: null }

--- a/src/assets/scripts/topBar/contactEvents.js
+++ b/src/assets/scripts/topBar/contactEvents.js
@@ -154,7 +154,9 @@ const handleContactEnded = async () => {
         await speechAnalysis.sessionClose();
     }
 
-    console.log(logStamp('handleContactEnded'), session.contact.outboundConnection
+    const outbound = session.contact.outboundConnection;
+    const unassignedOutboundCall = outbound && !session.user;
+    console.log(logStamp('handleContactEnded'), outbound
         ? 'outbound'
         : (session.contact.inboundConnection
             ? 'inbound'
@@ -165,7 +167,7 @@ const handleContactEnded = async () => {
         await appendTicketComments.appendTheRest(session.contact, session.ticketId);
         if (appSettings.speechAnalysisEnabled)
             speechAnalysis.updateTicketAttribute(session.ticketId.toString());
-    } else if (appSettings.forceTicketCreation && !(session.isMonitoring)) {
+    } else if (appSettings.forceTicketCreation && !(session.isMonitoring) && !unassignedOutboundCall) {
         // manual assignment mode, the agent has forgotten to assign - force ticket creation (if configured)
         // set the agent as a requester
         session.user = { name: session.contact.customerNo, id: null }


### PR DESCRIPTION
Ticket was erroneously created in agent mode for an unrecognised dialed number at the end of the call.