### PR TITLE
Dev 1783 typo

### DIFF
--- a/add-ons/contact-lens/packaged.yml
+++ b/add-ons/contact-lens/packaged.yml
@@ -48,8 +48,8 @@ Metadata:
       Zendesk Support ticket. To be used with the Amazon Connect app for Zendesk.
     Author: VoiceFoundry-APAC
     SpdxLicenseId: GPL-3.0-or-later
-    LicenseUrl: s3://214558022353-connect-zendesk-ap-southeast-2/zendesk-add-ons/contact-lens/e62637ea8a114355b985fd86c9ffbd6e
-    ReadmeUrl: s3://214558022353-connect-zendesk-ap-southeast-2/zendesk-add-ons/contact-lens/c8fbd6d06b83a4dbae7bb792ec772357
+    LicenseUrl: s3://214558022353-connect-zendesk-ap-southeast-2/zendesk-add-ons/contact-lens//e62637ea8a114355b985fd86c9ffbd6e
+    ReadmeUrl: s3://214558022353-connect-zendesk-ap-southeast-2/zendesk-add-ons/contact-lens//c8fbd6d06b83a4dbae7bb792ec772357
     Labels:
     - Connnect
     - Contact-Lens
@@ -85,7 +85,7 @@ Resources:
         and updates the matching Zendesk support ticket
       Runtime: nodejs12.x
       Handler: index.handler
-      CodeUri: s3://214558022353-connect-zendesk-ap-southeast-2/zendesk-add-ons/contact-lens/b8dc42d486cebb09d843c1462d389e3f
+      CodeUri: s3://214558022353-connect-zendesk-ap-southeast-2/zendesk-add-ons/contact-lens//f06f4120b2a29457f16fa97eeaae66bb
       Timeout: 240
       Policies:
       - AWSLambdaBasicExecutionRole

--- a/add-ons/contact-lens/packaged.yml
+++ b/add-ons/contact-lens/packaged.yml
@@ -48,8 +48,8 @@ Metadata:
       Zendesk Support ticket. To be used with the Amazon Connect app for Zendesk.
     Author: VoiceFoundry-APAC
     SpdxLicenseId: GPL-3.0-or-later
-    LicenseUrl: s3://214558022353-connect-zendesk-ap-southeast-2/zendesk-add-ons/contact-lens//e62637ea8a114355b985fd86c9ffbd6e
-    ReadmeUrl: s3://214558022353-connect-zendesk-ap-southeast-2/zendesk-add-ons/contact-lens//c8fbd6d06b83a4dbae7bb792ec772357
+    LicenseUrl: s3://214558022353-connect-zendesk-ap-southeast-2/zendesk-add-ons/contact-lens/e62637ea8a114355b985fd86c9ffbd6e
+    ReadmeUrl: s3://214558022353-connect-zendesk-ap-southeast-2/zendesk-add-ons/contact-lens/c8fbd6d06b83a4dbae7bb792ec772357
     Labels:
     - Connnect
     - Contact-Lens
@@ -57,7 +57,7 @@ Metadata:
     - Sentiment
     - Transcript
     HomePageUrl: https://github.com/voicefoundryap/amazon-connect-for-zendesk/tree/master/add-ons/contact-lens
-    SemanticVersion: 1.0.1
+    SemanticVersion: 1.0.2
     SourceCodeUrl: https://github.com/voicefoundryap/amazon-connect-for-zendesk/tree/master/add-ons/contact-lens
 Resources:
   tableZendeskRetries:
@@ -85,7 +85,7 @@ Resources:
         and updates the matching Zendesk support ticket
       Runtime: nodejs12.x
       Handler: index.handler
-      CodeUri: s3://214558022353-connect-zendesk-ap-southeast-2/zendesk-add-ons/contact-lens//f06f4120b2a29457f16fa97eeaae66bb
+      CodeUri: s3://214558022353-connect-zendesk-ap-southeast-2/zendesk-add-ons/contact-lens/f06f4120b2a29457f16fa97eeaae66bb
       Timeout: 240
       Policies:
       - AWSLambdaBasicExecutionRole

--- a/add-ons/contact-lens/template.yml
+++ b/add-ons/contact-lens/template.yml
@@ -49,7 +49,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['Connnect','Contact-Lens', 'Zendesk', 'Sentiment', 'Transcript']
     HomePageUrl: https://github.com/voicefoundryap/amazon-connect-for-zendesk/tree/master/add-ons/contact-lens
-    SemanticVersion: 1.0.1
+    SemanticVersion: 1.0.2
     SourceCodeUrl: https://github.com/voicefoundryap/amazon-connect-for-zendesk/tree/master/add-ons/contact-lens
 
 Resources:

--- a/add-ons/contact-lens/updateTicket/ticketComment.js
+++ b/add-ons/contact-lens/updateTicket/ticketComment.js
@@ -27,7 +27,7 @@ const buildOverallSentiment = (analysis, side) => {
     const negativeRate = calcSentimentRate('NEGATIVE');
     const neutralRate = calcSentimentRate('NEUTRAL');
     const mixedRate = 100 - (positiveRate + negativeRate + neutralRate);
-    return `<p><strong>${side}</strong> overal sentiment: ${overallLabel}</p>` +
+    return `<p><strong>${side}</strong> overall sentiment: ${overallLabel}</p>` +
         `<p>Positive: ${positiveRate}%</p><p>Negative: ${negativeRate}%</p><p>Neutral: ${neutralRate}%</p><p>Mixed: ${mixedRate}%</p>`;
 };
 


### PR DESCRIPTION
There was a typo in the Sentiment Analysis Ticket Update
`Customer overal sentiment: ` - should be `overall`